### PR TITLE
Log winner when there are four in a row, horizontally

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -102,6 +102,7 @@ const Game = () => {
           newBoard[i * columns + j + 1] = "win";
           newBoard[i * columns + j + 2] = "win";
           newBoard[i * columns + j + 3] = "win";
+          setWinner(player);
         }
       }
     }


### PR DESCRIPTION
We're detecting a win by horizontally placing four chips properly, but not actually selecting a winner.

Setting the winner fixes #5 