### PR TITLE
Add support for game ending in a draw

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -89,6 +89,8 @@ const Game = () => {
       }
     }
 
+    let isWinningMove = false;
+
     // row check
     for (let i = 0; i < rows; i++) {
       for (let j = 0; j < columns - 3; j++) {
@@ -102,7 +104,7 @@ const Game = () => {
           newBoard[i * columns + j + 1] = "win";
           newBoard[i * columns + j + 2] = "win";
           newBoard[i * columns + j + 3] = "win";
-          setWinner(player);
+          isWinningMove = true;
         }
       }
     }
@@ -120,7 +122,7 @@ const Game = () => {
           newBoard[(i + 1) * columns + j] = "win";
           newBoard[(i + 2) * columns + j] = "win";
           newBoard[(i + 3) * columns + j] = "win";
-          setWinner(player);
+          isWinningMove = true;
         }
       }
 
@@ -136,7 +138,7 @@ const Game = () => {
           newBoard[(i + 1) * columns + j + 1] = "win";
           newBoard[(i + 2) * columns + j + 2] = "win";
           newBoard[(i + 3) * columns + j + 3] = "win";
-          setWinner(player);
+          isWinningMove = true;
         }
         if (
           newBoard[i * columns + j + 3] === player &&
@@ -148,12 +150,21 @@ const Game = () => {
           newBoard[(i + 1) * columns + j + 2] = "win";
           newBoard[(i + 2) * columns + j + 1] = "win";
           newBoard[(i + 3) * columns + j] = "win";
-          setWinner(player);
+          isWinningMove = true;
         }
       }
     }
 
     if (validMove) {
+      setWinner((winner) => {
+        if (isWinningMove) {
+          return player;
+        }
+        if (newBoard.every((item) => item != null)) {
+          return "draw";
+        }
+        return winner;
+      });
       setBoard(newBoard);
       setPlayer(player === "red" ? "yellow" : "red");
     }


### PR DESCRIPTION
We weren't checking to see if the move was the last one available.  If the last move didn't produce a winner and there are no open spots left, declare a draw (we supported a draw, but never declared one before this!)

Fixes #1