### PR TITLE
Single Player Opponent: Assign random scores to available moves in a range

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -334,17 +334,21 @@ const useResultReaction = (params: UseResultReactionParams) => {
 
   const sadShapes = useMemo(
     () =>
-      ["😢", "😩", "😧", "😖", "🤬"].map((text) =>
-        confetti.shapeFromText({ text, scalar: 15 }),
-      ),
+      OffscreenCanvas != null
+        ? ["😢", "😩", "😧", "😖", "🤬"].map((text) =>
+            confetti.shapeFromText({ text, scalar: 15 }),
+          )
+        : undefined,
     [],
   );
   //
   const drawShapes = useMemo(
     () =>
-      ["👔", "🙈", "🙅", "😑", "😐"].map((text) =>
-        confetti.shapeFromText({ text, scalar: 15 }),
-      ),
+      OffscreenCanvas != null
+        ? ["👔", "🙈", "🙅", "😑", "😐"].map((text) =>
+            confetti.shapeFromText({ text, scalar: 15 }),
+          )
+        : undefined,
     [],
   );
 
@@ -358,7 +362,10 @@ const useResultReaction = (params: UseResultReactionParams) => {
       })?.catch(() => {
         // ignore confetti-related errors
       });
-    } else if (isDraw || isDismal) {
+    } else if (
+      (isDraw && drawShapes != null) ||
+      (isDismal && sadShapes != null)
+    ) {
       confetti({
         spread: 0,
         gravity: 0.65,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,9 @@ import Head from "next/head";
 import { useEffect, useMemo, useState } from "react";
 import confetti from "canvas-confetti";
 
+/** canvas-confetti uses OffscreenCanvas */
+const isOffscreenCanvasSupported = typeof OffscreenCanvas !== "undefined";
+
 interface Board<TValue = number> {
   values: Array<TValue>;
   columns: number;
@@ -334,7 +337,7 @@ const useResultReaction = (params: UseResultReactionParams) => {
 
   const sadShapes = useMemo(
     () =>
-      OffscreenCanvas != null
+      isOffscreenCanvasSupported
         ? ["😢", "😩", "😧", "😖", "🤬"].map((text) =>
             confetti.shapeFromText({ text, scalar: 15 }),
           )
@@ -344,7 +347,7 @@ const useResultReaction = (params: UseResultReactionParams) => {
   //
   const drawShapes = useMemo(
     () =>
-      OffscreenCanvas != null
+      isOffscreenCanvasSupported
         ? ["👔", "🙈", "🙅", "😑", "😐"].map((text) =>
             confetti.shapeFromText({ text, scalar: 15 }),
           )


### PR DESCRIPTION
Addresses #10 

Randomize the scores a bit to make the single player opponent a bit less predictable.

Also added a function for getting the lowest empty cell.