### PR TITLE
Fix oblong board cells at low column counts

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -28,7 +28,7 @@ export const Board = (props: BoardProps) => {
   return (
     <div className="min-w-96 border-8 border-solid border-blue-600 bg-gradient-to-b from-blue-700 to-blue-800 p-2 shadow-inner drop-shadow-md">
       <div
-        className="grid gap-2"
+        className="grid justify-items-center gap-2"
         style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
       >
         {Array(columns * rows)


### PR DESCRIPTION
Apply `justify-items: center` to the grid so cells don't stretch to fill 1fr columns when the board is narrow.

Fixes #17