### PR TITLE
Reset game state when settings change

### DIFF
--- a/src/context/GameState.tsx
+++ b/src/context/GameState.tsx
@@ -43,10 +43,12 @@ export const GameStateProvider = (props: GameStateProviderProps) => {
   const [currentPlayer, setCurrentPlayer] = useState<Player>(PLAYER_ONE);
   const [winner, setWinner] = useState<Player | "draw" | null>(null);
 
-  // reset the board when the number of rows or columns changes
+  // reset the board when any setting changes
   useEffect(() => {
     setValues(Array<BoardValue>(rows * columns).fill(undefined));
-  }, [columns, rows]);
+    setCurrentPlayer(PLAYER_ONE);
+    setWinner(null);
+  }, [columns, rows, players]);
 
   return (
     <PlayersContext.Provider value={players}>


### PR DESCRIPTION
The useEffect that resets board values on columns/rows change was not resetting currentPlayer or winner, leaving a finished game's result visible after changing settings. Also extend the effect to react to players changes.

Fixes #16