### PR TITLE
Fix pill-shaped cells on narrow screens

### DIFF
--- a/src/components/Circle.tsx
+++ b/src/components/Circle.tsx
@@ -39,7 +39,7 @@ export const Circle = (props: CircleProps) => {
 
   return (
     <div
-      className={`min-h-8 min-w-8 rounded-full ${isEmphasized ? "border-4 border-solid border-blue-500" : ""} text-lg shadow-lg ${isDense ? "" : "sm:min-h-16 sm:min-w-16"}`}
+      className={`aspect-square min-h-8 min-w-8 rounded-full ${isEmphasized ? "border-4 border-solid border-blue-500" : ""} text-lg shadow-lg ${isDense ? "" : "sm:min-h-16 sm:min-w-16"}`}
       {...(onClick != null
         ? {
             onClick,


### PR DESCRIPTION
Add aspect-square to Circle's outer div so the cell is always a square regardless of how the grid sizes the row. Without this, Safari and narrow viewports produce taller rows than columns, making rounded-full render as a pill instead of a circle.

Fixes #20