### PR TITLE
Clean up Circle styling

### DIFF
--- a/src/components/Circle.tsx
+++ b/src/components/Circle.tsx
@@ -28,7 +28,7 @@ export const Circle = (props: CircleProps) => {
 
   return (
     <div
-      className={`aspect-square min-w-8 rounded-full ${isEmphasized ? "border-4 border-solid border-blue-500" : ""} shadow-lg ${isDense ? "" : "sm:min-w-16"}`}
+      className={`relative aspect-square min-w-8 rounded-full ${isEmphasized ? "border-4 border-solid border-blue-500" : ""} shadow-lg ${isDense ? "" : "sm:min-w-16"}`}
       onClick={onClick}
       role={onClick != null ? "button" : undefined}
       tabIndex={onClick != null ? (isDisabled ? -1 : 0) : undefined}
@@ -43,7 +43,7 @@ export const Circle = (props: CircleProps) => {
       aria-label={color !== "empty" ? color : "empty slot"}
     >
       <div
-        className={`flex aspect-square w-full select-none items-center justify-center rounded-full border-4 text-lg ${isWinner ? "animate-pulse" : ""} ${colorClasses[color]}`}
+        className={`absolute inset-0 flex select-none items-center justify-center rounded-full border-4 text-lg ${isWinner ? "animate-pulse" : ""} ${colorClasses[color]}`}
       >
         {!isDense && color !== "empty" && "4"}
       </div>

--- a/src/components/Circle.tsx
+++ b/src/components/Circle.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 export interface CircleProps {
   onClick?: () => void;
   color?: "empty" | "red" | "yellow" | "purple" | "green";
@@ -7,6 +5,14 @@ export interface CircleProps {
   isDense?: boolean;
   isWinner?: boolean;
 }
+
+const colorClasses: Record<NonNullable<CircleProps["color"]>, string> = {
+  empty: "border-gray-200 bg-white",
+  red: "border-red-500 bg-red-700 text-red-500",
+  yellow: "border-amber-200 bg-amber-400 text-amber-200",
+  purple: "border-purple-500 bg-purple-700 text-purple-500",
+  green: "border-green-500 bg-green-600 text-green-500",
+};
 
 /** represents a space on the board - during game play, clicking a circle selects the lowest empty space in its column */
 export const Circle = (props: CircleProps) => {
@@ -18,47 +24,28 @@ export const Circle = (props: CircleProps) => {
     isWinner = false,
   } = props;
 
-  const colorClasses = useMemo(() => {
-    if (color === "red") {
-      return "border-red-500 bg-red-700 text-red-500";
-    }
-    if (color === "yellow") {
-      return "border-amber-200 bg-amber-400 text-amber-200";
-    }
-    if (color === "purple") {
-      return "border-purple-500 bg-purple-700 text-purple-500";
-    }
-    if (color === "green") {
-      return "border-green-500 bg-green-600 text-green-500";
-    }
-    return "border-gray-200 bg-white";
-  }, [color]);
-
-  // non-empty circles are not clickable
   const isDisabled = color !== "empty";
 
   return (
     <div
-      className={`aspect-square min-h-8 min-w-8 rounded-full ${isEmphasized ? "border-4 border-solid border-blue-500" : ""} text-lg shadow-lg ${isDense ? "" : "sm:min-h-16 sm:min-w-16"}`}
-      {...(onClick != null
-        ? {
-            onClick,
-            role: "button",
-            tabIndex: isDisabled ? -1 : 0,
-            "aria-disabled": isDisabled,
-            onKeyDown: (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                onClick();
-              }
-            },
-          }
-        : {})}
+      className={`aspect-square min-w-8 rounded-full ${isEmphasized ? "border-4 border-solid border-blue-500" : ""} shadow-lg ${isDense ? "" : "sm:min-w-16"}`}
+      onClick={onClick}
+      role={onClick != null ? "button" : undefined}
+      tabIndex={onClick != null ? (isDisabled ? -1 : 0) : undefined}
+      aria-disabled={onClick != null ? isDisabled : undefined}
+      onKeyDown={
+        onClick != null
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") onClick();
+            }
+          : undefined
+      }
       aria-label={color !== "empty" ? color : "empty slot"}
     >
       <div
-        className={`flex size-full select-none items-center justify-center rounded-full border-4 ${isWinner ? "animate-pulse" : ""} ${colorClasses}`}
+        className={`flex aspect-square w-full select-none items-center justify-center rounded-full border-4 text-lg ${isWinner ? "animate-pulse" : ""} ${colorClasses[color]}`}
       >
-        {isDense ? null : color !== "empty" ? "4" : <>&nbsp;</>}
+        {!isDense && color !== "empty" && "4"}
       </div>
     </div>
   );


### PR DESCRIPTION
- Add aspect-square to inner div to fix pill-shaped chips on Safari, where height: 100% doesn't resolve correctly against a parent sized via aspect-ratio
- Remove redundant min-h-* (aspect-square ties height to width)
- Replace useMemo + if-chain with a constant color record
- Replace conditional spread with individual conditional props
- Move text-lg to inner div where the text lives
- Remove &nbsp; placeholder (inner div is sized by aspect-square, not content)
- w-full replaces size-full on inner div since aspect-square handles height